### PR TITLE
Update resent view behavior

### DIFF
--- a/GitBlamePR/View/ContentView.swift
+++ b/GitBlamePR/View/ContentView.swift
@@ -68,6 +68,7 @@ struct GitBlamePRView: View {
                             model: model.recent,
                             textOnTap: { text in
                                 self.fullPathTextFieldValue = text
+                                self.textOnCommit(self.fullPathTextFieldValue)
                             },
                             clearOnTap: {
                                 self.clearOnTap()

--- a/GitBlamePR/View/RecentView.swift
+++ b/GitBlamePR/View/RecentView.swift
@@ -13,9 +13,15 @@ struct RecentViewModel {
 }
 
 struct RecentView: View {
-    var model: RecentViewModel
-    var textOnTap: (String) -> Void
-    var clearOnTap: () -> Void
+    private var model: RecentViewModel
+    private var textOnTap: (String) -> Void
+    private var clearOnTap: () -> Void
+
+    init(model: RecentViewModel, textOnTap: @escaping (String) -> Void, clearOnTap: @escaping () -> Void) {
+        self.model = model
+        self.textOnTap = textOnTap
+        self.clearOnTap = clearOnTap
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
Show results as soon as you tap full path in resent view.