### PR TITLE
Fix assertion failure in AppKit.subproj/NSView.m:5646

### DIFF
--- a/GitBlamePR/View/Revision/PullRequestView.swift
+++ b/GitBlamePR/View/Revision/PullRequestView.swift
@@ -16,10 +16,11 @@ struct PullRequestView: View {
         viewMaker: .init(image: { (str) -> AnyView in
             let urlStr = str.split(separator: " ")[0]
             return AnyView(
-                    KFImage(URL(string: String(urlStr)))
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                )
+                KFImage(URL(string: String(urlStr)))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(minWidth: 0, idealWidth: nil, maxWidth: 800, minHeight: nil, idealHeight: nil, maxHeight: nil, alignment: .top)
+            )
         }),
         viewModifier: .init(link: { (link) -> AnyView in
             let urlStr = link.url.split(separator: " ")[0]


### PR DESCRIPTION
*** Assertion failure in -[_TtC7SwiftUIP33_A874FC5B9DB530D4375C25AE2AA39DF215HostingClipView setBoundsOrigin:], /BuildRoot/Library/Caches/com.apple.xbs/Sources/AppKit/AppKit-1894.30.142/AppKit.subproj/NSView.m:5646

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x00007fff3035a1e7 AppKit`-[NSApplication _crashOnException:] + 106
    frame #1: 0x00007fff30119dc2 AppKit`__62+[CATransaction(NSCATransaction) NS_setFlushesWithDisplayLink]_block_invoke + 805
    frame #2: 0x00007fff3083565d AppKit`___NSRunLoopObserverCreateWithHandler_block_invoke + 41
    frame #3: 0x00007fff32db40ee CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
    frame #4: 0x00007fff32db4014 CoreFoundation`__CFRunLoopDoObservers + 457
    frame #5: 0x00007fff32db370b CoreFoundation`__CFRunLoopRun + 1219
    frame #6: 0x00007fff32db2bd3 CoreFoundation`CFRunLoopRunSpecific + 499
    frame #7: 0x00007fff3190865d HIToolbox`RunCurrentEventLoopInMode + 292
    frame #8: 0x00007fff319082a9 HIToolbox`ReceiveNextEventCommon + 356
    frame #9: 0x00007fff31908127 HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 64
    frame #10: 0x00007fff2ff78ba4 AppKit`_DPSNextEvent + 990
    frame #11: 0x00007fff2ff77380 AppKit`-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352
    frame #12: 0x00007fff2ff6909e AppKit`-[NSApplication run] + 658
    frame #13: 0x00007fff2ff3b465 AppKit`NSApplicationMain + 777
  * frame #14: 0x000000010005097d GitBlamePR`main at AppDelegate.swift:13:7
    frame #15: 0x00007fff6a4587fd libdyld.dylib`start + 1
    frame #16: 0x00007fff6a4587fd libdyld.dylib`start + 1
(lldb) 
```